### PR TITLE
Use lodash.assignin instead of loading entire lodash library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-extend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A simple 'extend' helper, adapted from the Backbone.js library.",
   "main": "simple-extend.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": ">=2.0.0"
+    "lodash.assignin": ">=4.2.0"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,10 @@
     "name": "Tim Griesser",
     "web": "https://github.com/tgriesser"
   },
+  "contributors": [{
+  	"name": "James Ballantine",
+  	"url": "https://github.com/jballant"
+  }], 
   "license": "MIT",
   "devDependencies": {
     "mocha": "~1.14.0",

--- a/simple-extend.js
+++ b/simple-extend.js
@@ -1,7 +1,7 @@
 // simple-extend.js 0.1.0
 // A simple 'extend' helper, adapted from the Backbone.js library.
 // http://github.com/tgriesser/simple-extend
-var _ = require('lodash');
+var assignIn = require('lodash.assignin');
 
 // Shared empty constructor function to aid in prototype-chain creation.
 var ctor = function() {};
@@ -23,7 +23,7 @@ module.exports = function(protoProps, staticProps) {
   }
 
   // Inherit class (static) properties from parent.
-  _.extend(child, parent);
+  assignIn(child, parent);
 
   // Set the prototype chain to inherit from `parent`, without calling
   // `parent`'s constructor function.
@@ -32,10 +32,10 @@ module.exports = function(protoProps, staticProps) {
 
   // Add prototype properties (instance properties) to the subclass,
   // if supplied.
-  if (protoProps) _.extend(child.prototype, protoProps);
+  if (protoProps) assignIn(child.prototype, protoProps);
 
   // Add static properties to the constructor function, if supplied.
-  if (staticProps) _.extend(child, staticProps);
+  if (staticProps) assignIn(child, staticProps);
 
   // Correctly set child's `prototype.constructor`.
   child.prototype.constructor = child;

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 var chai   = require('chai');
 var expect = chai.expect;
-var _      = require('lodash');
 var extend = require('../simple-extend');
 
 describe('extend', function () {


### PR DESCRIPTION
Loading the entire lodash library to just use the `_.extend` function is unnecessary. If you are bundling this module using something like Webpack, that means that you are potentially adding a non-trivial amount of code to your build for just one function. 

I modified this module to just use the [lodash.assign](https://www.npmjs.com/package/lodash.assignin) module as the object properties copying function. It means much less code if this module is bundled into a client build.
